### PR TITLE
Add additional regex replacement to remove style=“xxx” parameters

### DIFF
--- a/amplify/twigextensions/AmplifyTwigExtension.php
+++ b/amplify/twigextensions/AmplifyTwigExtension.php
@@ -37,6 +37,11 @@ class AmplifyTwigExtension extends Twig_Extension
       #removes empty paragraphs
       $pattern = "/<p[^>]*><\\/p[^>]*>/";
       $html = preg_replace($pattern, '', $html);
+
+      #remove style=""
+      $pattern = '/style=\".+\"/';
+      $html = preg_replace($pattern, '', $html);
+
       return $html;
     }
 }


### PR DESCRIPTION
Style parameters are disallowed by AMP, but they may pop up in user-generated content in Craft, either through direct HTML editing or from resizing images inside a rich text field.